### PR TITLE
Import improvements

### DIFF
--- a/Editor/Blacklister.cs
+++ b/Editor/Blacklister.cs
@@ -8,7 +8,7 @@ namespace RiskOfThunder.RoR2Importer
     {
         public override string Name => "RoR2 Assembly Blacklist";
 
-        public override int Priority => 0;
+        public override int Priority => 1_000;
 
         public override IEnumerable<string> Process(IEnumerable<string> blacklist)
         {

--- a/Editor/LegacyResourceAPIPatcher.cs
+++ b/Editor/LegacyResourceAPIPatcher.cs
@@ -27,7 +27,7 @@ namespace RiskOfThunder.RoR2Importer
             var settings = ThunderKitSetting.GetOrCreateSettings<ThunderKitSettings>();
             var legacyResourceAPIOrig = Path.GetFullPath(Path.Combine(settings.ManagedAssembliesPath, "LegacyResourcesAPI.dll"));
             var legacyResourceAPINew = Path.GetFullPath(Path.Combine(settings.PackageFilePath, "LegacyResourcesAPI.dll"));
-            var diffPath = Path.GetFullPath(Path.Combine("Packages", "ror2importer", "BinaryDiff", "LegacyResourcesAPI.diff"));
+            var diffPath = Path.GetFullPath(Path.Combine("Packages", "riskofthunder-ror2importer", "BinaryDiff", "LegacyResourcesAPI.diff"));
             var packagePath = Path.GetDirectoryName(legacyResourceAPINew);
 
             if (File.Exists(legacyResourceAPINew))

--- a/Editor/LegacyResourceAPIPatcher.cs
+++ b/Editor/LegacyResourceAPIPatcher.cs
@@ -19,6 +19,7 @@ namespace RiskOfThunder.RoR2Importer
     {
         public override string Name => string.IsNullOrEmpty(extensionName) ? extensionName = "RoR2 LegacyResourceAPI Patcher" : extensionName;
 
+        public override string Description => $"Patches the game's LegacyResourcesAPI.dll to improve stability and reduce editor hangs.";
         public override int Priority => Constants.ConfigPriority.AssemblyImport - 250_000;
 
         public override void Execute()

--- a/Editor/PackageInstaller.cs
+++ b/Editor/PackageInstaller.cs
@@ -18,6 +18,9 @@ namespace RiskOfThunder.RoR2Importer
     {
         public override string Name => string.IsNullOrEmpty(extensionName) ? extensionName = "RoR2 Package Installer" : extensionName;
 
+        public override string Description => $"Modifies your project's Packages folder:" +
+            $"\nInstall Unity's PostProcessingPackage (Version 2.3.0)" +
+            $"\nRemoves Unity's TextMeshPro package";
         public override int Priority => Constants.ConfigPriority.AssemblyImport + 250_000;
 
         public override void Execute()

--- a/Editor/PublicizerAssemblyProcessor.cs
+++ b/Editor/PublicizerAssemblyProcessor.cs
@@ -49,7 +49,7 @@ namespace RiskOfThunder.RoR2Importer
 
             List<string> arguments = new List<string>
             {
-                "NStrip",
+                "nstrip.exe",
                 "-p",
                 "-n",
                 $"-d \"{ror2ManagedDir}\"",
@@ -61,8 +61,9 @@ namespace RiskOfThunder.RoR2Importer
                 $"\"{outputPath}\""
             };
 
-            List<string> log = new List<string> { $"Publicizedd {assemblyFileName} with the following arguments:" };
+            List<string> log = new List<string> { $"Publicized {assemblyFileName} with the following arguments:" };
             log.AddRange(StripAssembly(arguments, nstripPath));
+            Debug.Log(string.Join("\n", log));
 
             return outputPath;
         }
@@ -75,20 +76,17 @@ namespace RiskOfThunder.RoR2Importer
             {
                 args.Append(arguments[i]);
                 args.Append(" ");
-                logger.Add($"Argument {i}: '{arguments[i]}'");
+                logger.Add($"Argument {i}: {arguments[i]}");
             }
 
             ProcessStartInfo psi = new ProcessStartInfo(nstripPath)
             {
                 WorkingDirectory = Path.GetDirectoryName(nstripPath),
                 Arguments = args.ToString(),
-                UseShellExecute = true
             };
             var process = System.Diagnostics.Process.Start(psi);
-            process.WaitForExit();
+            process.WaitForExit(5000);
             return logger;
         }
-
-
     }
 }

--- a/Editor/PublicizerAssemblyProcessor.cs
+++ b/Editor/PublicizerAssemblyProcessor.cs
@@ -1,6 +1,15 @@
 ﻿using System.IO;
 using ThunderKit.Core.Config;
+using UnityEngine;
+using System.Diagnostics;
+using Debug = UnityEngine.Debug;
 using UObject = UnityEngine.Object;
+using System.Threading.Tasks;
+using UnityEditor;
+using System.Collections.Generic;
+using ThunderKit.Core.Data;
+using ThunderKit.Core.Paths;
+using System.Text;
 
 namespace RiskOfThunder.RoR2Importer
 {
@@ -8,20 +17,78 @@ namespace RiskOfThunder.RoR2Importer
     {
         public override int Priority => 500;
         public override string Name => $"Assembly Publicizer";
-
-        public override string Process(string path)
+        public override string Process(string assemblyPath)
         {
             PublicizerDataStorer dataStorer = PublicizerDataStorer.GetDataStorer();
             //Publicizer not enabled? dont publicize
             if(!dataStorer.enabled)
-                return path;
+                return assemblyPath;
 
-            var assemblyFileName = Path.GetFileName(path);
+            var assemblyFileName = Path.GetFileName(assemblyPath);
             //assembly file name is not in assemblyNames? dont publicize.
             if (!dataStorer.assemblyNames.Contains(assemblyFileName))
-                return path;
+                return assemblyPath;
 
-            return path;
+            UObject nstripExe = dataStorer.nStripExecutable;
+            if (nstripExe == null)
+            {
+                Debug.LogWarning($"Could not strip assembly {assemblyFileName}, as NStrip has not been located.");
+                return assemblyPath;
+            }
+
+            string ror2ManagedDir = ThunderKitSetting.GetOrCreateSettings<ThunderKitSettings>().ManagedAssembliesPath;
+
+            string thunderkitRoot = Application.dataPath.Replace("Assets", "ThunderKit");
+            string nstripFolder = Path.Combine(thunderkitRoot, "NStrip");
+            if(!Directory.Exists(nstripFolder))
+            {
+                Directory.CreateDirectory(nstripFolder);
+            }
+            string outputPath = Path.Combine(nstripFolder, assemblyFileName);
+            string nstripPath = Path.GetFullPath(AssetDatabase.GetAssetPath(nstripExe));
+
+            List<string> arguments = new List<string>
+            {
+                "NStrip",
+                "-p",
+                "-n",
+                $"-d \"{ror2ManagedDir}\"",
+                "-cg",
+                "-cg-exclude-events",
+                "-remove-readonly",
+                "-unity-non-serialized",
+                $"\"{assemblyPath}\"",
+                $"\"{outputPath}\""
+            };
+
+            List<string> log = new List<string> { $"Publicizedd {assemblyFileName} with the following arguments:" };
+            log.AddRange(StripAssembly(arguments, nstripPath));
+
+            return outputPath;
         }
+
+        private List<string> StripAssembly(List<string> arguments, string nstripPath)
+        {
+            var args = new StringBuilder();
+            var logger = new List<string>();
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                args.Append(arguments[i]);
+                args.Append(" ");
+                logger.Add($"Argument {i}: '{arguments[i]}'");
+            }
+
+            ProcessStartInfo psi = new ProcessStartInfo(nstripPath)
+            {
+                WorkingDirectory = Path.GetDirectoryName(nstripPath),
+                Arguments = args.ToString(),
+                UseShellExecute = true
+            };
+            var process = System.Diagnostics.Process.Start(psi);
+            process.WaitForExit();
+            return logger;
+        }
+
+
     }
 }

--- a/Editor/PublicizerAssemblyProcessor.cs
+++ b/Editor/PublicizerAssemblyProcessor.cs
@@ -1,0 +1,15 @@
+﻿using ThunderKit.Core.Config;
+
+namespace RiskOfThunder.RoR2Importer
+{
+    public class PublicizerAssemblyProcessor : AssemblyProcessor
+    {
+        public override int Priority => -10;
+        public override string Name => $"Assembly Publicizer";
+
+        public override string Process(string path)
+        {
+            return path;
+        }
+    }
+}

--- a/Editor/PublicizerAssemblyProcessor.cs
+++ b/Editor/PublicizerAssemblyProcessor.cs
@@ -1,14 +1,26 @@
-﻿using ThunderKit.Core.Config;
+﻿using System.IO;
+using ThunderKit.Core.Config;
+using UObject = UnityEngine.Object;
 
 namespace RiskOfThunder.RoR2Importer
 {
     public class PublicizerAssemblyProcessor : AssemblyProcessor
     {
-        public override int Priority => -10;
+        public override int Priority => 500;
         public override string Name => $"Assembly Publicizer";
 
         public override string Process(string path)
         {
+            PublicizerDataStorer dataStorer = PublicizerDataStorer.GetDataStorer();
+            //Publicizer not enabled? dont publicize
+            if(!dataStorer.enabled)
+                return path;
+
+            var assemblyFileName = Path.GetFileName(path);
+            //assembly file name is not in assemblyNames? dont publicize.
+            if (!dataStorer.assemblyNames.Contains(assemblyFileName))
+                return path;
+
             return path;
         }
     }

--- a/Editor/PublicizerAssemblyProcessor.cs
+++ b/Editor/PublicizerAssemblyProcessor.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using ThunderKit.Core.Data;
 using ThunderKit.Core.Paths;
 using System.Text;
+using System.Linq;
 
 namespace RiskOfThunder.RoR2Importer
 {
@@ -49,16 +50,15 @@ namespace RiskOfThunder.RoR2Importer
 
             List<string> arguments = new List<string>
             {
-                "nstrip.exe",
                 "-p",
                 "-n",
-                $"-d \"{ror2ManagedDir}\"",
+                "-d", ror2ManagedDir,
                 "-cg",
-                "-cg-exclude-events",
-                "-remove-readonly",
-                "-unity-non-serialized",
-                $"\"{assemblyPath}\"",
-                $"\"{outputPath}\""
+                "--cg-exclude-events",
+                "--remove-readonly",
+                "--unity-non-serialized",
+                assemblyPath,
+                outputPath
             };
 
             List<string> log = new List<string> { $"Publicized {assemblyFileName} with the following arguments:" };
@@ -70,20 +70,19 @@ namespace RiskOfThunder.RoR2Importer
 
         private List<string> StripAssembly(List<string> arguments, string nstripPath)
         {
-            var args = new StringBuilder();
             var logger = new List<string>();
             for (int i = 0; i < arguments.Count; i++)
             {
-                args.Append(arguments[i]);
-                args.Append(" ");
                 logger.Add($"Argument {i}: {arguments[i]}");
             }
 
             ProcessStartInfo psi = new ProcessStartInfo(nstripPath)
             {
                 WorkingDirectory = Path.GetDirectoryName(nstripPath),
-                Arguments = args.ToString(),
             };
+
+            psi.Arguments = string.Join(" ", arguments.Select(arg => $"\"{arg}\""));
+
             var process = System.Diagnostics.Process.Start(psi);
             process.WaitForExit(5000);
             return logger;

--- a/Editor/PublicizerAssemblyProcessor.cs.meta
+++ b/Editor/PublicizerAssemblyProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6fb6a405e8b0f2e4c9943d07eaa72c75
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/PublicizerDataStorer.cs
+++ b/Editor/PublicizerDataStorer.cs
@@ -95,7 +95,6 @@ namespace RiskOfThunder.RoR2Importer
             var relativePath = AssetDatabase.GetAssetPath(nstrip);
             var fullPath = Path.GetFullPath(relativePath);
             var fileName = Path.GetFileName(fullPath);
-            Debug.Log(fileName == "NStrip.exe");
 
             if (fileName != "NStrip.exe")
             {

--- a/Editor/PublicizerDataStorer.cs
+++ b/Editor/PublicizerDataStorer.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using ThunderKit.Core.Config;
+using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+namespace RiskOfThunder.RoR2Importer
+{
+    public class PublicizerDataStorer : OptionalExecutor
+    {
+        public override string Name => "Assembly Publicizer";
+        public override string Description => "Assemblies listed in here will be publicized using NStrip." +
+            "\nPublicized assemblies retain their inspector look and functionality, this does not strip assemblies.";
+        public override int Priority => ThunderKit.Common.Constants.ConfigPriority.AssemblyImport + 125_000;
+
+        public List<string> assemblyNames = new List<string> { "RoR2.dll" };
+
+        public override void Execute()
+        { }
+
+        protected override VisualElement CreateProperties()
+        {
+            SerializedObject obj = new SerializedObject(this);
+            PropertyField propField = new PropertyField(obj.FindProperty(nameof(assemblyNames)));
+            return propField;
+        }
+    }
+}

--- a/Editor/PublicizerDataStorer.cs
+++ b/Editor/PublicizerDataStorer.cs
@@ -1,28 +1,127 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using ThunderKit.Core.Config;
+using ThunderKit.Core.Data;
+using ThunderKit.Markdown;
 using UnityEditor;
 using UnityEditor.UIElements;
+using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace RiskOfThunder.RoR2Importer
 {
     public class PublicizerDataStorer : OptionalExecutor
     {
+        public const string NStripExePath = "Packages/bepinex-nstrip/NStrip.exe";
         public override string Name => "Assembly Publicizer";
         public override string Description => "Assemblies listed in here will be publicized using NStrip." +
             "\nPublicized assemblies retain their inspector look and functionality, this does not strip assemblies.";
         public override int Priority => ThunderKit.Common.Constants.ConfigPriority.AssemblyImport + 125_000;
 
-        public List<string> assemblyNames = new List<string> { "RoR2.dll" };
+        public List<string> assemblyNames = new List<string> { "RoR2.dll", "KinematicCharacterController.dll" };
+
+        public UnityEngine.Object nStripExecutable;
+
+        private SerializedObject serializedObject;
+        private VisualElement rootVisualElement;
+        private MarkdownElement MessageElement
+        {
+            get
+            {
+                if(_messageElement == null)
+                {
+                    _messageElement = new MarkdownElement();
+                    _messageElement.MarkdownDataType = MarkdownDataType.Text;
+                }
+                return _messageElement;
+            }
+        }
+        private MarkdownElement _messageElement;
 
         public override void Execute()
         { }
 
         protected override VisualElement CreateProperties()
         {
-            SerializedObject obj = new SerializedObject(this);
-            PropertyField propField = new PropertyField(obj.FindProperty(nameof(assemblyNames)));
-            return propField;
+            serializedObject = new SerializedObject(this);
+            var executableProperty = serializedObject.FindProperty(nameof(nStripExecutable));
+            var assemblyList = serializedObject.FindProperty(nameof(assemblyNames));
+            rootVisualElement = new VisualElement();
+
+            //Nstrip should ideally be located automatically, This method should find it if nstrip is in Packages, which it should be.
+            if (executableProperty.objectReferenceValue == null)
+            {
+                //If NStrip couldnt be located, display warning
+                if(TryToFindNStripExecutable(out var executable))
+                {
+                    executableProperty.objectReferenceValue = executable;
+                    serializedObject.ApplyModifiedProperties();
+                }
+                else
+                {
+                    MessageElement.Data = $"***__WARNING__***: Could not find NStrip Executable! Hover over the \"N Strip Executable\" field for instructions.";
+                    rootVisualElement.Add(MessageElement);
+                }
+            }
+
+            PropertyField nstripField = new PropertyField(executableProperty);
+            nstripField.tooltip = $"The NStrip executable, this is used for the publicizing system" +
+                $"\nIf this field appears to be empty, then the RoR2Importer has failed to find the executable automatically." +
+                $"\nPlease select the NStrip executable in your project, if no Executable exists, download NStrip version 1.4 or newer";
+            nstripField.RegisterCallback<ChangeEvent<UnityEngine.Object>>(OnNStripSet);
+            rootVisualElement.Add(nstripField);
+
+            PropertyField listField = new PropertyField(assemblyList);
+            listField.tooltip = $"A list of assembly names to publicize, Case Sensitive.";
+            rootVisualElement.Add(listField);
+            return rootVisualElement;
+        }
+
+        private void OnNStripSet(ChangeEvent<UnityEngine.Object> evt)
+        {
+            var nstrip = evt.newValue;
+            if (nstrip == null)
+            {
+                MessageElement.Data = $"***__WARNING__***: Could not find NStrip Executable! Hover over the \"N Strip Executable\" field for instructions.";
+                if(!rootVisualElement.Contains(MessageElement))
+                {
+                    rootVisualElement.Add(MessageElement);
+                }
+                return;
+            }
+
+            var relativePath = AssetDatabase.GetAssetPath(nstrip);
+            var fullPath = Path.GetFullPath(relativePath);
+            var fileName = Path.GetFileName(fullPath);
+            Debug.Log(fileName == "NStrip.exe");
+
+            if (fileName != "NStrip.exe")
+            {
+                MessageElement.Data = $"Object in \"N Strip Executable\" is not NStrip!";
+                if(!rootVisualElement.Contains(MessageElement))
+                {
+                    rootVisualElement.Add(MessageElement);
+                }
+                return;
+            }
+
+            MessageElement.RemoveFromHierarchy();
+        }
+
+        private bool TryToFindNStripExecutable(out UnityEngine.Object nstripExecutable)
+        {
+            var nstrip = AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(NStripExePath);
+            nstripExecutable = nstrip == null ? null : nstrip;
+            return nstripExecutable != null;
+        }
+
+        internal static PublicizerDataStorer GetDataStorer()
+        {
+            var settings = ThunderKitSetting.GetOrCreateSettings<ImportConfiguration>();
+            var publicizerDataStorer = settings.ConfigurationExecutors.OfType<PublicizerDataStorer>().FirstOrDefault();
+            return publicizerDataStorer;
         }
     }
 }

--- a/Editor/PublicizerDataStorer.cs.meta
+++ b/Editor/PublicizerDataStorer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2636f9900aca35942b349a07d34faaf4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/RoR2Importers.asmdef
+++ b/Editor/RoR2Importers.asmdef
@@ -4,7 +4,8 @@
         "ThunderKit.Core",
         "ThunderKit.Common",
         "BsDiff",
-        "ThunderKit.Markdown"
+        "ThunderKit.Markdown",
+        "ThunderKit.Thunderstore"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Editor/RoR2Importers.asmdef
+++ b/Editor/RoR2Importers.asmdef
@@ -3,7 +3,8 @@
     "references": [
         "ThunderKit.Core",
         "ThunderKit.Common",
-        "BsDiff"
+        "BsDiff",
+        "ThunderKit.Markdown"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Editor/ThunderstorePackageInstaller.cs
+++ b/Editor/ThunderstorePackageInstaller.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ThunderKit.Common;
+using ThunderKit.Core.Config;
+using ThunderKit.Core.Data;
+using ThunderKit.Core.UIElements;
+using ThunderKit.Integrations.Thunderstore;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace RiskOfThunder.RoR2Importer
+{
+    public class ThunderstorePackageInstaller : OptionalExecutor
+    {
+        public override int Priority => ThunderKit.Common.Constants.ConfigPriority.AddressableCatalog - 50_000;
+        public override string Description => $"Thunderstore related import options for RoR2";
+        public override string Name => $"Thunderstore Package Installer";
+
+        public bool createRoR2Source = true;
+
+        public bool installModsFromRoR2Source = true;
+        public List<string> ror2ModGUIDs = new List<string> { };
+
+        public bool installThunderKitExtensions = true;
+        public List<string> editorExtensionGUIDs = new List<string> { };
+
+        private VisualElement rootElement;
+
+        [SerializeField]
+        private ThunderstoreSource ror2Source;
+
+        protected override VisualElement CreateProperties()
+        {
+            rootElement = TemplateHelpers.LoadTemplateInstance("Packages/riskofthunder-rorimporter/Editor/ThunderstorePackageInstaller.uxml", rootElement);
+            rootElement.AddEnvironmentAwareSheets(Constants.ThunderKitSettingsTemplatePath);
+            return rootElement;
+        }
+
+        public override void Execute()
+        {
+            if(createRoR2Source)
+            {
+                if(ror2Source == null)
+                    CreateRoR2Source();
+                PackageSource.LoadAllSources();
+            }
+
+            if(createRoR2Source && installModsFromRoR2Source && ror2ModGUIDs.Count > 0)
+            {
+                InstallModsFromRoR2Source();
+            }
+
+            if(installThunderKitExtensions && editorExtensionGUIDs.Count > 0)
+            {
+                InstallThunderKitExtensions();
+            }
+        }
+
+        private void CreateRoR2Source()
+        {
+            ror2Source = CreateInstance<ThunderstoreSource>();
+            ror2Source.Url = "https://thunderstore.io";
+            AssetDatabase.CreateAsset(ror2Source, "Assets/ThunderKitSettings/RoR2Thunderstore.asset");
+            PackageSource.LoadAllSources();
+        }
+
+        private void InstallModsFromRoR2Source()
+        {
+
+        }
+
+        private void InstallThunderKitExtensions()
+        {
+
+        }
+    }
+}

--- a/Editor/ThunderstorePackageInstaller.cs
+++ b/Editor/ThunderstorePackageInstaller.cs
@@ -35,7 +35,7 @@ namespace RiskOfThunder.RoR2Importer
 
         protected override VisualElement CreateProperties()
         {
-            rootElement = TemplateHelpers.LoadTemplateInstance("Packages/riskofthunder-rorimporter/Editor/ThunderstorePackageInstaller.uxml", rootElement);
+            rootElement = TemplateHelpers.LoadTemplateInstance("Packages/riskofthunder-ror2importer/Editor/ThunderstorePackageInstaller.uxml", rootElement);
             rootElement.AddEnvironmentAwareSheets(Constants.ThunderKitSettingsTemplatePath);
             return rootElement;
         }

--- a/Editor/ThunderstorePackageInstaller.cs.meta
+++ b/Editor/ThunderstorePackageInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f40d5c29c1971ae498df375727144e31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ThunderstorePackageInstaller.uxml
+++ b/Editor/ThunderstorePackageInstaller.uxml
@@ -1,0 +1,7 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
+    <uie:PropertyField binding-path="createRoR2Source" tooltip="Creates a new Thunderstore Source and sets the URL to &quot;https://thunderstore.io&quot;" />
+    <uie:PropertyField binding-path="installModsFromRoR2Source" tooltip="Installs the mods listed in &quot;RoR 2 Mod Guids&quot;" />
+    <uie:PropertyField binding-path="ror2ModGUIDs" tooltip="A list of GUIDS of mods to install to the project" />
+    <uie:PropertyField binding-path="installThunderKitExtensions" tooltip="Installs the extensions listed in &quot;Editor Extension GUIDS" />
+    <uie:PropertyField binding-path="editorExtensionGUIDs" tooltip="A list of GUIDS of extensions to install to the project" />
+</ui:UXML>

--- a/Editor/ThunderstorePackageInstaller.uxml
+++ b/Editor/ThunderstorePackageInstaller.uxml
@@ -1,7 +1,20 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
-    <uie:PropertyField binding-path="createRoR2Source" tooltip="Creates a new Thunderstore Source and sets the URL to &quot;https://thunderstore.io&quot;" />
-    <uie:PropertyField binding-path="installModsFromRoR2Source" tooltip="Installs the mods listed in &quot;RoR 2 Mod Guids&quot;" />
-    <uie:PropertyField binding-path="ror2ModGUIDs" tooltip="A list of GUIDS of mods to install to the project" />
-    <uie:PropertyField binding-path="installThunderKitExtensions" tooltip="Installs the extensions listed in &quot;Editor Extension GUIDS" />
-    <uie:PropertyField binding-path="editorExtensionGUIDs" tooltip="A list of GUIDS of extensions to install to the project" />
+    <uie:PropertyField
+        binding-path="createRoR2Source"
+        label="Create RoR2 Thunderstore Source"
+        tooltip="Creates a new Thunderstore Source and sets the URL to &quot;https://thunderstore.io&quot;" />
+    <uie:EnumFlagsField
+        binding-path="ror2Dependencies"
+        name="ror2-dependencies"
+        class="thunderkit-field-input"
+        type="RiskOfThunder.RoR2Importer.ThunderstorePackageInstaller+CommonRoR2Dependencies, RoR2Importers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+        label="Common RoR2 Dependencies"
+        tooltip="An enum of common ror2 dependencies, each flag represents a mod that'll be installed to the project" />
+    <uie:EnumFlagsField
+        binding-path="thunderKitExtensions"
+        name="thunderkit-extensions"
+        class="thunderkit-field-input"
+        type="RiskOfThunder.RoR2Importer.ThunderstorePackageInstaller+CommonRoR2ThunderKitExtensions, RoR2Importers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"
+        label="Common RoR2 ThunderKit Extensions"
+        tooltip="An enum of common thunderkit extensions, each flag represents an extension that'll be installed to the project" />
 </ui:UXML>

--- a/Editor/ThunderstorePackageInstaller.uxml.meta
+++ b/Editor/ThunderstorePackageInstaller.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 4231218897dd9834589da87d0016be41
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Editor/Whitelister.cs
+++ b/Editor/Whitelister.cs
@@ -8,7 +8,7 @@ namespace RiskOfThunder.RoR2Importer
     {
         public override string Name => "RoR2 Assembly Whitelist";
 
-        public override int Priority => 0;
+        public override int Priority => 750;
 
         public override IEnumerable<string> Process(IEnumerable<string> whitelist)
         {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "riskofthunder-rorimporter",
+  "name": "riskofthunder-ror2importer",
   "author": {
     "name": "PassivePicasso",
     "email": "",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ror2importer",
+  "name": "riskofthunder-rorimporter",
   "author": {
     "name": "PassivePicasso",
     "email": "",


### PR DESCRIPTION
Improves the importer's capabilities in a myriad of ways.

1.- Adds Descrpiton properties to the PackageInstaller and the LegacyResourceAPIPatcher, these properties where added in thunderkit's 74th pull request (https://github.com/PassivePicasso/ThunderKit/pull/74)
2.- Added publicizer capabilities by using NStrip 1.4, Someone under the bepinex team needs to publish the version 1.4 of NStrip to the thunderkit.thunderstore.io website before we can publish the importer
    * Publicizer comes in a PublicizerDataStorer (Optional Executor) which saves the location of the NStrip executable and the assemblies to publicize
    * Publicier also contains an AssemblyProcessor which is used for the publicizing procecss.
3.- Added arbitraty priority values to the RoR2 assembly whitelister and blacklister
4.- Added a thunderstore package installer, installer automatically adds the RoR2 source if it doesnt exist and attempts to add common extensions and mods to the project if theyre enabled, common mods include BepInExPack and R2API, while common extensions include RoR2EditorKit and RoR2MultiplayerHLAPI.

Known issues:
1.- Thunderstore package installer cant install the ror2 mod dependencies if the ror2 source didnt exist at the time, might be a timing issue
2.- Thunderstore package installer doesnt seem to install RoR2MultiplayerHALpi
3.- None of the optional executors are stylized properly